### PR TITLE
force to use npm version 6 for stable build

### DIFF
--- a/how-to-build-joplin-for-atm64-devices.md
+++ b/how-to-build-joplin-for-atm64-devices.md
@@ -4,7 +4,8 @@
 ## Step 2 Install the dependencies
 ```
 apt-get update && apt-get dist-upgrade -y && apt-get -y install curl && curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt-get -y install nodejs build-essential git jq libsecret-1-dev rsync python ruby ruby-dev libnss3
-npm install -g npm
+
+npm install npm@6 -g
 gem install --no-document fp
 ```
 


### PR DESCRIPTION
npm version 6 was needed for stable build. In my case i can't go ahead to next step ever with npm version 7.
